### PR TITLE
fix: replace init() panic with structured error + apply AI-suggested labels filtered against existing

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"auto-pr/internal/ai"
 	"auto-pr/internal/config"
@@ -36,8 +37,8 @@ func init() {
 	createCmd.Flags().String("ai-context", "", "Additional context file")
 
 	if err := viper.BindPFlags(createCmd.Flags()); err != nil {
-		// This should not happen in practice
-		panic(fmt.Errorf("failed to bind flags: %w", err))
+		fmt.Fprintf(os.Stderr, "error: failed to bind create flags: %v\n", err)
+		os.Exit(1)
 	}
 }
 
@@ -213,9 +214,15 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	// Merge configuration with AI suggestions
-	labels := []string{} // Skip labels for now to avoid non-existent label error
-	// TODO: Check if labels exist before applying them
+	// Filter AI-suggested labels to only those that exist in the repository,
+	// so we don't attempt to apply a label that hasn't been created yet.
+	labels, err := platforms.FilterExistingLabels(platformClient, aiResponse.Labels)
+	if err != nil {
+		if verbose {
+			fmt.Printf("Warning: failed to verify labels, skipping: %v\n", err)
+		}
+		labels = []string{}
+	}
 
 	reviewers := aiResponse.Reviewers
 	if len(cfg.Platforms.GitHub.DefaultReviewers) > 0 && platform == types.PlatformGitHub {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,10 +33,12 @@ func init() {
 	rootCmd.PersistentFlags().Bool("dry-run", false, "preview changes without executing")
 
 	if err := viper.BindPFlag("verbose", rootCmd.PersistentFlags().Lookup("verbose")); err != nil {
-		panic(fmt.Errorf("failed to bind verbose flag: %w", err))
+		fmt.Fprintf(os.Stderr, "error: failed to bind verbose flag: %v\n", err)
+		os.Exit(1)
 	}
 	if err := viper.BindPFlag("dry-run", rootCmd.PersistentFlags().Lookup("dry-run")); err != nil {
-		panic(fmt.Errorf("failed to bind dry-run flag: %w", err))
+		fmt.Fprintf(os.Stderr, "error: failed to bind dry-run flag: %v\n", err)
+		os.Exit(1)
 	}
 }
 

--- a/internal/platforms/github.go
+++ b/internal/platforms/github.go
@@ -198,6 +198,31 @@ func (g *GitHubClient) GetCLIPath() string {
 	return g.cliPath
 }
 
+// ListLabels returns all label names defined in the repository.
+func (g *GitHubClient) ListLabels() ([]string, error) {
+	cmd := exec.Command(g.cliPath, "label", "list",
+		"--repo", fmt.Sprintf("%s/%s", g.repoOwner, g.repoName),
+		"--json", "name",
+		"--limit", "100")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list labels: %w", err)
+	}
+
+	var items []struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(output, &items); err != nil {
+		return nil, fmt.Errorf("failed to parse label list: %w", err)
+	}
+
+	names := make([]string, len(items))
+	for i, item := range items {
+		names[i] = item.Name
+	}
+	return names, nil
+}
+
 // getPRDetails gets detailed information about a PR from its URL
 func (g *GitHubClient) getPRDetails(prURL string) (*types.PullRequest, error) {
 	// Extract PR number from URL

--- a/internal/platforms/gitlab.go
+++ b/internal/platforms/gitlab.go
@@ -191,6 +191,30 @@ func (g *GitLabClient) GetCLIPath() string {
 	return g.cliPath
 }
 
+// ListLabels returns all label names defined in the repository.
+func (g *GitLabClient) ListLabels() ([]string, error) {
+	cmd := exec.Command(g.cliPath, "label", "list",
+		"--repo", g.projectID,
+		"--output", "json")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list labels: %w", err)
+	}
+
+	var items []struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(output, &items); err != nil {
+		return nil, fmt.Errorf("failed to parse label list: %w", err)
+	}
+
+	names := make([]string, len(items))
+	for i, item := range items {
+		names[i] = item.Name
+	}
+	return names, nil
+}
+
 // getMRDetails gets detailed information about an MR from its URL
 func (g *GitLabClient) getMRDetails(mrURL string) (*types.PullRequest, error) {
 	// Extract MR IID from URL

--- a/internal/platforms/interface.go
+++ b/internal/platforms/interface.go
@@ -21,4 +21,32 @@ type PlatformClient interface {
 
 	// GetCLIPath returns the path to the platform's CLI tool
 	GetCLIPath() string
+
+	// ListLabels returns all label names defined in the repository
+	ListLabels() ([]string, error)
+}
+
+// FilterExistingLabels returns only those labels from candidates that exist in the repository.
+func FilterExistingLabels(client PlatformClient, candidates []string) ([]string, error) {
+	if len(candidates) == 0 {
+		return []string{}, nil
+	}
+	existing, err := client.ListLabels()
+	if err != nil {
+		return []string{}, err
+	}
+	set := make(map[string]struct{}, len(existing))
+	for _, l := range existing {
+		set[l] = struct{}{}
+	}
+	var filtered []string
+	for _, c := range candidates {
+		if _, ok := set[c]; ok {
+			filtered = append(filtered, c)
+		}
+	}
+	if filtered == nil {
+		return []string{}, nil
+	}
+	return filtered, nil
 }

--- a/internal/platforms/labels_test.go
+++ b/internal/platforms/labels_test.go
@@ -1,0 +1,76 @@
+package platforms
+
+import (
+	"testing"
+
+	"auto-pr/pkg/types"
+)
+
+// stubClient implements PlatformClient with a fixed label set for testing.
+type stubClient struct {
+	labels []string
+	err    error
+}
+
+func (s *stubClient) DetectPlatform(repoURL string) (types.PlatformType, error) { return types.PlatformGitHub, nil }
+func (s *stubClient) IsAuthenticated() bool                                      { return true }
+func (s *stubClient) CreatePullRequest(req *types.PullRequestRequest) (*types.PullRequest, error) {
+	return nil, nil
+}
+func (s *stubClient) GetExistingPR(branch string) (*types.PullRequest, error) { return nil, nil }
+func (s *stubClient) ValidateRepository() error                                { return nil }
+func (s *stubClient) GetCLIPath() string                                       { return "" }
+func (s *stubClient) ListLabels() ([]string, error)                            { return s.labels, s.err }
+
+func TestFilterExistingLabels(t *testing.T) {
+	tests := []struct {
+		name           string
+		repoLabels     []string
+		candidates     []string
+		want           []string
+		wantErr        bool
+	}{
+		{
+			name:       "keeps only labels that exist",
+			repoLabels: []string{"bug", "feature", "docs"},
+			candidates: []string{"bug", "feature", "nonexistent"},
+			want:       []string{"bug", "feature"},
+		},
+		{
+			name:       "all candidates nonexistent returns empty slice",
+			repoLabels: []string{"bug", "feature"},
+			candidates: []string{"nonexistent", "also-missing"},
+			want:       []string{},
+		},
+		{
+			name:       "empty candidates returns empty slice",
+			repoLabels: []string{"bug"},
+			candidates: []string{},
+			want:       []string{},
+		},
+		{
+			name:       "all candidates exist",
+			repoLabels: []string{"bug", "feature"},
+			candidates: []string{"bug", "feature"},
+			want:       []string{"bug", "feature"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &stubClient{labels: tt.repoLabels}
+			got, err := FilterExistingLabels(client, tt.candidates)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("FilterExistingLabels() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("FilterExistingLabels() = %v, want %v", got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("FilterExistingLabels()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **Panic fix:** Both `cmd/root.go` and `cmd/create.go` called `panic()` in `init()` to handle viper flag-binding errors, with a comment saying "should not happen in practice." Panics in `init()` dump a stack trace; replaced with `fmt.Fprintf(os.Stderr, ...)` + `os.Exit(1)` for a clean error message. Flag-binding errors *can* happen (e.g., cobra command re-registration in tests, duplicate flag names).
- **Label fix (Option A — implement the check):** The original code had `labels := []string{} // Skip labels for now` with `// TODO: Check if labels exist before applying them`, silently discarding all AI-suggested labels. Implemented the check: added `ListLabels()` to `PlatformClient` (via `gh label list` for GitHub, `glab label list` for GitLab), added `FilterExistingLabels()` helper in the `platforms` package, and wired it into `runCreate` so AI-suggested labels are applied when they exist in the repo. If the label-list call fails, labels are skipped gracefully with a verbose-mode warning — same behaviour as before, but now opt-in rather than always.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all existing tests green)
- [x] New unit test `TestFilterExistingLabels` covers: partial match, all nonexistent → empty slice, empty candidates → empty slice, all exist → all returned
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)